### PR TITLE
 RDKVREFPLT-6047 [RTK] Refactoring the secure memory and session handling

### DIFF
--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -524,14 +524,7 @@ MediaKeySession::MediaKeySession(const uint8_t *f_pbInitData, uint32_t f_cbInitD
 #ifdef USE_SVP
   gst_svp_ext_get_context(&m_pSVPContext, Client, 0);
 
-  m_stSecureBuffInfo.bCreateSecureMemRegion = true;
-  m_stSecureBuffInfo.SecureMemRegionSize = 512 * 1024;
-
-  if( 0 != svp_allocate_secure_buffers(m_pSVPContext, (void**)&m_stSecureBuffInfo, nullptr, nullptr, m_stSecureBuffInfo.SecureMemRegionSize))
-  {
-      /* No need to break here */
-      m_stSecureBuffInfo.SecureMemRegionSize = 0;
-  }
+  svp_init_secure_memory(m_pSVPContext, (void**)&m_stSecureBuffInfo);
 #endif
 
   std::string initData(reinterpret_cast<const char*>(f_pbInitData), f_cbInitData);
@@ -620,6 +613,15 @@ MediaKeySession::~MediaKeySession(void)
 {
     mMaxResDecodePixels = 0;
     mMaxResDecodeSet = false;
+#ifdef USE_SVP
+    if(0 != svp_deinit_secure_memory(m_pSVPContext, (void*)&m_stSecureBuffInfo))
+    {
+        fprintf(stderr, "[%s:%d]  secure memory, free failed",__FUNCTION__,__LINE__);
+    }
+
+    gst_svp_ext_free_context(m_pSVPContext);
+    m_pSVPContext = NULL;
+#endif
     Close();
 
 }
@@ -1286,19 +1288,6 @@ void MediaKeySession::DeleteInMemoryLicenses()  {
 CDMi_RESULT MediaKeySession::Close(void) {
 
     if ( m_eKeyState != KEY_CLOSED ) {
-#ifdef USE_SVP
-        m_stSecureBuffInfo.bReleaseSecureMemRegion = true;
-        if(0 != svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, nullptr, nullptr, 0))
-        {
-            fprintf(stderr, "[%s:%d]  secure memory, free failed",__FUNCTION__,__LINE__);
-        }
-        else {
-            m_stSecureBuffInfo.bCreateSecureMemRegion = false;
-            m_stSecureBuffInfo.SecureMemRegionSize = 0;
-        }
-        gst_svp_ext_free_context(m_pSVPContext);
-        m_pSVPContext = NULL;
-#endif
 
         SAFE_OEM_FREE(m_pbChallenge);
 
@@ -1514,26 +1503,6 @@ CDMi_RESULT MediaKeySession::Decrypt(
 
   if(useSVP)
   {
-    // Reallocate input memory if needed.
-    if(m_stSecureBuffInfo.bCreateSecureMemRegion)
-    {
-        if (actualEncDataLength >  m_stSecureBuffInfo.SecureMemRegionSize) {
-            m_stSecureBuffInfo.bReleaseSecureMemRegion = true;
-            if(0 != svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, nullptr, nullptr, 0))
-            {
-                fprintf(stderr, "[%s:%d]  Secure memory free falied",__FUNCTION__,__LINE__);
-                return CDMi_S_FALSE;
-            }
-            m_stSecureBuffInfo.SecureMemRegionSize = actualEncDataLength;
-            m_stSecureBuffInfo.bReleaseSecureMemRegion = false;
-
-            if(0 != svp_allocate_secure_buffers(m_pSVPContext, (void**)&m_stSecureBuffInfo, nullptr, nullptr, m_stSecureBuffInfo.SecureMemRegionSize))
-            {
-                fprintf(stderr, "[%s:%d] Secure memory, re-allocation failed %d",__FUNCTION__,__LINE__, m_stSecureBuffInfo.SecureMemRegionSize);
-                return CDMi_S_FALSE;
-            }
-        }
-    }
 
     m_stSecureBuffInfo.patternClearBlocks = sampleInfo->pattern.clear_blocks;
 
@@ -1551,18 +1520,16 @@ CDMi_RESULT MediaKeySession::Decrypt(
     bGstSvpStatus = svp_buffer_alloc_token(&pSecureToken);
     if (!bGstSvpStatus) {
         fprintf(stderr, "[%s:%d]  memory allocation for Token is failure",__FUNCTION__,__LINE__);
-        m_stSecureBuffInfo.bReleaseSecureMemRegion = false;
         // Free decrypted secure buffer.
-        svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, (void*)m_stSecureBuffInfo.pAVSecBuffer , nullptr, 0);
+        svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, nullptr, nullptr, 0);
         return CDMi_S_FALSE;
     }
 
     bGstSvpStatus = svp_buffer_to_token(m_pSVPContext, (void *)&m_stSecureBuffInfo, pSecureToken);
     if (!bGstSvpStatus) {
         fprintf(stderr, "[%s:%d]  Buffer to Token creation is failure",__FUNCTION__,__LINE__);
-        m_stSecureBuffInfo.bReleaseSecureMemRegion = false;
         // Free decrypted secure buffer.
-        svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, (void*)m_stSecureBuffInfo.pAVSecBuffer , nullptr, 0);
+        svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, nullptr, nullptr, 0);
         svp_buffer_free_token(pSecureToken);
         return CDMi_S_FALSE;
     }
@@ -1661,9 +1628,8 @@ CDMi_RESULT MediaKeySession::Decrypt(
 #ifdef USE_SVP
     if (useSVP)
     {
-      m_stSecureBuffInfo.bReleaseSecureMemRegion = false;
       // Free decrypted secure buffer.
-      svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, (void*)m_stSecureBuffInfo.pAVSecBuffer , nullptr, 0);
+      svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, nullptr , nullptr, 0);
       svp_buffer_free_token(pSecureToken);
     }
 #endif
@@ -1680,6 +1646,9 @@ CDMi_RESULT MediaKeySession::Decrypt(
 
     memcpy((void *)(uint8_t*)pEncryptedDataStart, pSecureToken, svp_token_size());
     svp_buffer_free_token(pSecureToken);
+
+    // Free decrypted secure buffer.
+    svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, nullptr, nullptr, 0);
   }
   else
   {
@@ -1695,13 +1664,6 @@ CDMi_RESULT MediaKeySession::Decrypt(
         pDecryptedContent = NULL;
     }
 
-  }
-
-  if (useSVP)
-  {
-    m_stSecureBuffInfo.bReleaseSecureMemRegion = false;
-    // Free decrypted secure buffer.
-    svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, nullptr , nullptr, 0);
   }
 
   if (!m_fCommit) {


### PR DESCRIPTION
Reason for change:
1. Splitted the secure session & secure memory allocate/free functionality by introducing new interface
2. Used the new svp_init_secure_memory() svp_deinit_secure_memory() APIs

Test Procedure: Verified the build and playback.

Risks: None.

Signed-off-by: antonyxavier_francis@comcast.com