### PR TITLE
RDKEVL-6881: [BCM] Vendor release layer cleanup on ocdm patches.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,20 @@ if(DEFINED USE_PLAYREADY_CMAKE)
     find_package(PlayReady REQUIRED)
 endif()
 
+if (BUILD_REFERENCE)
+    add_definitions(-DBUILD_REFERENCE=${BUILD_REFERENCE})
+endif()
+
+if(DEFINED PLAYREADY_BROADCOM)
+    message(STATUS "PLAYREADY_BROADCOM is defined")
+    find_package(WPEFramework REQUIRED)
+    find_package(${NAMESPACE}Core REQUIRED)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/broadcom")
+    find_package(NEXUS REQUIRED)
+    find_package(NXCLIENT REQUIRED)
+    find_package(NexusPlayready REQUIRED)
+endif()
+
 find_package(OpenSSL REQUIRED)
 
 file(GLOB DRM_PLUGIN_INCLUDES *.h)
@@ -47,11 +61,20 @@ set(DRM_PLUGIN_LIBS
     ${PLAYREADY_LIBRARIES})
 endif()
 
+if(DEFINED PLAYREADY_BROADCOM)
+set(DRM_PLUGIN_LIBS 
+    ${LIBNexusPlayready_LIBRARIES})
+endif()
+
 set(DRM_PLUGIN_SOURCES 
     MediaSession.cpp 
     MediaSystem.cpp
     MediaSessionExt.cpp)
 
+if(DEFINED PLAYREADY_BROADCOM)
+string(REPLACE "-Wl,--as-needed" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-as-needed")
+endif()
 
 # add the library
 add_library(${DRM_PLUGIN_NAME} SHARED ${DRM_PLUGIN_SOURCES})
@@ -61,6 +84,27 @@ target_compile_definitions(${DRM_PLUGIN_NAME} PRIVATE ${PLAYREADY_FLAGS})
 target_include_directories(${DRM_PLUGIN_NAME} PRIVATE ${PLAYREADY_INCLUDE_DIRS})
 target_link_libraries(${DRM_PLUGIN_NAME} ${DRM_PLUGIN_LIBS})
 endif()
+
+if(DEFINED PLAYREADY_BROADCOM)
+add_definitions( -DENABLE_AMBIGUOUS_FIX)
+target_compile_definitions(${DRM_PLUGIN_NAME} 
+    PRIVATE 
+        BSTD_CPU_ENDIAN=BSTD_ENDIAN_LITTLE
+        USE_PK_NAMESPACES=1
+        DRM_INCLUDE_PK_NAMESPACE_USING_STATEMENT=1
+        DRM_BUILD_PROFILE=900
+        USE_SVP=1
+)
+endif()
+
+if(DEFINED PLAYREADY_BROADCOM)
+target_link_libraries(${DRM_PLUGIN_NAME} ${DRM_PLUGIN_LIBS})
+endif()
+
+set_target_properties(${DRM_PLUGIN_NAME} PROPERTIES 
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED YES
+)
 
 set_target_properties(${DRM_PLUGIN_NAME} PROPERTIES SUFFIX ".drm")
 set_target_properties(${DRM_PLUGIN_NAME} PROPERTIES PREFIX "")
@@ -72,8 +116,8 @@ if(DEFINED PLAYREADY_REALTEK)
     target_link_libraries(${DRM_PLUGIN_NAME} PRIVATE playreadypk)
     message(STATUS "PLAYREADY_REALTEK is ON")
 elseif(DEFINED PLAYREADY_BROADCOM)
-    #target_link_libraries(${DRM_PLUGIN_NAME} PRIVATE NEXUS::NEXUS NXCLIENT::NXCLIENT NexusWidevine::NexusWidevine)
-    #message(STATUS "PLAYREADY_BROADCOM is ON")
+    target_link_libraries(${DRM_PLUGIN_NAME} PRIVATE ${NAMESPACE}Core::${NAMESPACE}Core NEXUS::NEXUS NXCLIENT::NXCLIENT NexusPlayready::NexusPlayready)
+    message(STATUS "PLAYREADY_BROADCOM is ON")
 endif()
 
 # Enable SVP.

--- a/cmake/broadcom/FindNEXUS.cmake
+++ b/cmake/broadcom/FindNEXUS.cmake
@@ -1,0 +1,71 @@
+# - Try to find Nexus.
+# Once done this will define
+#  NEXUS_FOUND  - System has Nexus
+#  NEXUS::NEXUS - The Nexus library
+#
+###
+# If not stated otherwise in this file or this component's LICENSE
+# file the following copyright and licenses apply:
+#
+# Copyright 2024 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+find_path(LIBNEXUS_INCLUDE nexus_config.h
+        PATH_SUFFIXES refsw)
+find_library(LIBNEXUS_LIBRARY nexus)
+if(EXISTS "${LIBNEXUS_LIBRARY}")
+    find_library(LIBB_OS_LIBRARY b_os)
+    find_library(LIBNEXUS_CLIENT_LIBRARY nexus_client)
+    find_library(LIBNXCLIENT_LIBRARY nxclient)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(NEXUS DEFAULT_MSG LIBNEXUS_INCLUDE LIBNEXUS_LIBRARY)
+    mark_as_advanced(LIBNEXUS_INCLUDE LIBNEXUS_LIBRARY)
+    if(NEXUS_FOUND AND NOT TARGET NEXUS::NEXUS)
+        add_library(NEXUS::NEXUS UNKNOWN IMPORTED)
+        set_target_properties(NEXUS::NEXUS PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                INTERFACE_INCLUDE_DIRECTORIES "${LIBNEXUS_INCLUDE}"
+                    )
+        if(NOT EXISTS "${LIBNEXUS_CLIENT_LIBRARY}")
+            message(STATUS "Nexus in Proxy mode")
+            set_target_properties(NEXUS::NEXUS PROPERTIES
+                    IMPORTED_LOCATION "${LIBNEXUS_LIBRARY}"
+                    )
+        else()
+            message(STATUS "Nexus in Client mode")
+            set_target_properties(NEXUS::NEXUS PROPERTIES
+                    IMPORTED_LOCATION "${LIBNEXUS_CLIENT_LIBRARY}"
+                    )
+        endif()
+        if(NOT EXISTS "${LIBNXCLIENT_LIBRARY}")
+            set_target_properties(NEXUS::NEXUS PROPERTIES
+                    INTERFACE_COMPILE_DEFINITIONS NO_NXCLIENT
+                    )
+        endif()
+        if(EXISTS "${LIBB_OS_LIBRARY}")
+            set_target_properties(NEXUS::NEXUS PROPERTIES
+                    IMPORTED_LINK_INTERFACE_LIBRARIES "${LIBB_OS_LIBRARY}"
+                    )
+        endif()
+    endif()
+    set_target_properties(NEXUS::NEXUS PROPERTIES
+            INTERFACE_COMPILE_DEFINITIONS "PLATFORM_BRCM"
+            )
+else()
+    if(NEXUS_FIND_REQUIRED)
+        message(FATAL_ERROR "LIBNEXUS_LIBRARY not available")
+    elseif(NOT NEXUS_FIND_QUIETLY)
+        message(STATUS "LIBNEXUS_LIBRARY not available")
+    endif()
+endif()

--- a/cmake/broadcom/FindNXCLIENT.cmake
+++ b/cmake/broadcom/FindNXCLIENT.cmake
@@ -1,0 +1,45 @@
+# - Try to find Nexus client.
+# Once done this will define
+#  NXCLIENT_FOUND     - System has a Nexus client
+#  NXCLIENT::NXCLIENT - The Nexus client library
+#
+###
+# If not stated otherwise in this file or this component's LICENSE
+# file the following copyright and licenses apply:
+#
+# Copyright 2024 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+find_path(LIBNXCLIENT_INCLUDE nexus_config.h
+        PATH_SUFFIXES refsw)
+find_library(LIBNXCLIENT_LIBRARY nxclient)
+if(EXISTS "${LIBNXCLIENT_LIBRARY}")
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(NXCLIENT DEFAULT_MSG LIBNXCLIENT_INCLUDE LIBNXCLIENT_LIBRARY)
+    mark_as_advanced(LIBNXCLIENT_LIBRARY)
+    if(NXCLIENT_FOUND AND NOT TARGET NXCLIENT::NXCLIENT)
+        add_library(NXCLIENT::NXCLIENT UNKNOWN IMPORTED)
+        set_target_properties(NXCLIENT::NXCLIENT PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${LIBNXCLIENT_LIBRARY}"
+                INTERFACE_INCLUDE_DIRECTORIES "${LIBNXCLIENT_INCLUDE}"
+                )
+    endif()
+else()
+    if(NXCLIENT_FIND_REQUIRED)
+        message(FATAL_ERROR "LIBNXCLIENT_LIBRARY not available")
+    elseif(NOT NXCLIENT_FIND_QUIETLY)
+        message(STATUS "LIBNXCLIENT_LIBRARY not available")
+    endif()
+endif()

--- a/cmake/broadcom/FindNexusPlayready.cmake
+++ b/cmake/broadcom/FindNexusPlayready.cmake
@@ -1,0 +1,70 @@
+# - Try to find Broadcom Nexus Playready.
+# Once done this will define
+#  NexusPlayready_FOUND     - System has a Nexus Playready
+#  NexusPlayready::NexusPlayready - The Nexus Playready library
+#
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+# Copyright (c) 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+find_path(LIBNexusPlayready_INCLUDE_DIR drmmanager.h
+        PATH_SUFFIXES playready refsw)
+
+find_path(LIBNexusSVP_INCLUDE_DIR sage_srai.h
+        PATH_SUFFIXES refsw)
+
+list(APPEND LIBNexusPlayready_INCLUDE_DIRS ${LIBNexusPlayready_INCLUDE_DIR} ${LIBNexusSVP_INCLUDE_DIR})
+
+# main lib
+find_library(LIBNexusPlayready_LIBRARY playready30pk)
+
+# needed libs
+list(APPEND NeededLibs prdyhttp)
+
+# needed svp libs
+list(APPEND NeededLibs drmrootfs srai)
+
+foreach (_library ${NeededLibs})
+    find_library(LIBRARY_${_library} ${_library})
+
+    if(NOT EXISTS "${LIBRARY_${_library}}")
+        message(SEND_ERROR "Could not find mandatory library: ${_library}")
+    endif()
+
+    list(APPEND LIBNexusPlayready_LIBRARIES ${LIBRARY_${_library}})
+
+endforeach ()
+
+if(EXISTS "${LIBNexusPlayready_LIBRARY}")
+    include(FindPackageHandleStandardArgs)
+    set(NexusPlayready_FOUND TRUE)
+
+    find_package_handle_standard_args(LIBNexusPlayready DEFAULT_MSG LIBNEXUS_INCLUDE LIBNexusPlayready_LIBRARY)
+
+    mark_as_advanced(LIBNexusPlayready_LIBRARY)
+
+    if(NOT TARGET NexusPlayready::NexusPlayready)
+        add_library(NexusPlayready::NexusPlayready UNKNOWN IMPORTED)
+        
+        set_target_properties(NexusPlayready::NexusPlayready PROPERTIES
+                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                IMPORTED_LOCATION "${LIBNexusPlayready_LIBRARY}"
+                INTERFACE_INCLUDE_DIRECTORIES "${LIBNexusPlayready_INCLUDE_DIRS}"
+                INTERFACE_LINK_LIBRARIES "${LIBNexusPlayready_LIBRARIES}"
+                )
+    endif()
+
+endif()


### PR DESCRIPTION
**Reason for change:** Vendor release layer cleanup on ocdm patches and upstream the changes.
**Test Procedure:** Build and verify.
**Risks:** High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com