### PR TITLE
RDKEVL-6880 [BCM] 74116 playready playback regression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,13 @@ else()
     message(STATUS "DRM_ANTI_ROLLBACK_CLOCK_SUPPORT is OFF")
 endif()
 
+if("${PLAYREADY_VERSION_4_6}" STREQUAL "ON")
+    add_definitions( -DPLAYREADY_VERSION_4_6=1 )
+    message(STATUS "PLAYREADY_VERSION_4_6 is ON")
+else()
+    message(STATUS "PLAYREADY_VERSION_4_6 is OFF")
+endif()
+
 if("${NO_PERSISTENT_LICENSE_CHECK}" STREQUAL "ON")
     add_definitions( -DNO_PERSISTENT_LICENSE_CHECK=1 )
     message(STATUS "NO_PERSISTENT_LICENSE_CHECK is ON")

--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -817,7 +817,7 @@ CDMi_RESULT MediaKeySession::Load(void) {
 CDMi_RESULT MediaKeySession::SetKeyIdProperty( const DRM_WCHAR *f_rgwchEncodedKid, DRM_DWORD f_cchEncodedKid ){
     DRM_RESULT err = Drm_Content_SetProperty(
             m_poAppContext,
-            DRM_CSP_AUTODETECT_HEADER,
+            DRM_CSP_SELECT_KID,
             (DRM_BYTE*)f_rgwchEncodedKid,
             f_cchEncodedKid * sizeof( DRM_WCHAR ) );
 

--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -270,7 +270,7 @@ public:
     {
         const uint32_t MAXLEN = 64;
         char versionStr[MAXLEN];
-#if defined (PLAYREADY_VERSION_4_6)
+#if defined PLAYREADY_VERSION_4_6
         if (g_dstrReqTagPKClientVersionData.cchString >= MAXLEN)
             return "";
         DRM_UTL_DemoteUNICODEtoASCII(g_dstrReqTagPKClientVersionData.pwszString,
@@ -284,7 +284,7 @@ public:
                 versionStr, MAXLEN);
         ((DRM_BYTE*)versionStr)[g_dstrReqTagPlayReadyClientVersionData.cchString] = 0;
         PackedCharsToNativeImpl(versionStr, g_dstrReqTagPlayReadyClientVersionData.cchString + 1);
-#endif /* !defined PLAYREADY_VERSION_4_6 */
+#endif /* PLAYREADY_VERSION_4_6 */
         return string(versionStr);
     }
 

--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -270,12 +270,21 @@ public:
     {
         const uint32_t MAXLEN = 64;
         char versionStr[MAXLEN];
+#if defined (PLAYREADY_VERSION_4_6)
+        if (g_dstrReqTagPKClientVersionData.cchString >= MAXLEN)
+            return "";
+        DRM_UTL_DemoteUNICODEtoASCII(g_dstrReqTagPKClientVersionData.pwszString,
+                versionStr, MAXLEN);
+        ((DRM_BYTE*)versionStr)[g_dstrReqTagPKClientVersionData.cchString] = 0;
+        PackedCharsToNativeImpl(versionStr, g_dstrReqTagPKClientVersionData.cchString + 1);
+#else
         if (g_dstrReqTagPlayReadyClientVersionData.cchString >= MAXLEN)
             return "";
         DRM_UTL_DemoteUNICODEtoASCII(g_dstrReqTagPlayReadyClientVersionData.pwszString,
                 versionStr, MAXLEN);
         ((DRM_BYTE*)versionStr)[g_dstrReqTagPlayReadyClientVersionData.cchString] = 0;
         PackedCharsToNativeImpl(versionStr, g_dstrReqTagPlayReadyClientVersionData.cchString + 1);
+#endif /* !defined PLAYREADY_VERSION_4_6 */
         return string(versionStr);
     }
 


### PR DESCRIPTION
Reason for change:
1. Fix the playready4_6 playback issue
2. Added the PLAYREADY_VERSION_4_6 macro to add the specific changes
3. Changed the Drm_Content_SetProperty() with DRM_CSP_SELECT_KID type to resolve the KID not found issue

Test Procedure: PlayReady playback verified

Risks: None.

Signed-off-by: antonyxavier_francis@comcast.com