### PR TITLE
RDKECOREMW-1553 : add playready support on Broadcom "athena" platform, BCM74110

### DIFF
--- a/cmake/broadcom/FindNexusPlayready.cmake
+++ b/cmake/broadcom/FindNexusPlayready.cmake
@@ -35,7 +35,7 @@ find_library(LIBNexusPlayready_LIBRARY playready30pk)
 list(APPEND NeededLibs prdyhttp)
 
 # needed svp libs
-list(APPEND NeededLibs drmrootfs srai)
+list(APPEND NeededLibs drmrootfs srai playready_tl)
 
 foreach (_library ${NeededLibs})
     find_library(LIBRARY_${_library} ${_library})


### PR DESCRIPTION
Reason for change: To update PlayReady host libs for PlayReady thin layer.

Ticket Reference - BCM-1692, SWSTB-29960
Author - Jian Wang <juventus.wang@broadcom.com>

Test Procedure: Verify the build and PR playback.
Risks: None.

Signed-off-by: thenmozhi_kathiravan@comcast.com