### PR TITLE
SWRDKV-5447: ocdm-playready defect fix.

### DIFF
--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -536,6 +536,7 @@ MediaKeySession::MediaKeySession(const uint8_t *f_pbInitData, uint32_t f_cbInitD
 
   std::string initData(reinterpret_cast<const char*>(f_pbInitData), f_cbInitData);
   std::string playreadyInitData;
+  SafeCriticalSection systemLock(drmAppContextMutex_);
 
   ChkBOOL(m_eKeyState == KEY_CLOSED, DRM_E_INVALIDARG);
 
@@ -708,6 +709,7 @@ void MediaKeySession::Run(const IMediaKeySessionCallback *f_piMediaKeySessionCal
 
 bool MediaKeySession::playreadyGenerateKeyRequest() {
 
+  SafeCriticalSection systemLock(drmAppContextMutex_);
   DRM_RESULT dr = DRM_SUCCESS;
   DRM_DWORD cchSilentURL = 0;
   SAFE_OEM_FREE( m_pbChallenge );
@@ -944,6 +946,7 @@ DRM_RESULT MediaKeySession::ReaderBind(
 }
 
 CDMi_RESULT MediaKeySession::PersistentLicenseCheck() {
+    SafeCriticalSection systemLock(drmAppContextMutex_);
 #ifdef NO_PERSISTENT_LICENSE_CHECK
     // DELIA-51437: The Webkit EME implementation used by OTT apps
     // such as Amazon and YouTube fails when the key is usable from
@@ -1129,6 +1132,7 @@ ErrorExit:
 /*processes the license response and creates decryptor for each valid ack available in the response*/
 void MediaKeySession::Update(const uint8_t *m_pbKeyMessageResponse, uint32_t  m_cbKeyMessageResponse) {
 
+    SafeCriticalSection systemLock(drmAppContextMutex_);
 
     DRM_RESULT dr = DRM_SUCCESS;
     DRM_LICENSE_RESPONSE oLicenseResponse = { eUnknownProtocol, 0 };
@@ -1285,6 +1289,7 @@ void MediaKeySession::DeleteInMemoryLicenses()  {
 
 CDMi_RESULT MediaKeySession::Close(void) {
 
+    SafeCriticalSection systemLock(drmAppContextMutex_);
     if ( m_eKeyState != KEY_CLOSED ) {
 #ifdef USE_SVP
         m_stSecureBuffInfo.bReleaseSecureMemRegion = true;
@@ -1683,6 +1688,12 @@ CDMi_RESULT MediaKeySession::Decrypt(
       gst_svp_header_set_field(m_pSVPContext, header, SvpHeaderFieldName::Type, TokenType::Handle);
     }
 
+    if (actualEncDataLength < svp_token_size()) {
+      svp_buffer_free_token(pSecureToken);
+      m_stSecureBuffInfo.bReleaseSecureMemRegion = false;
+      svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, nullptr , nullptr, 0);
+      return CDMi_S_FALSE;
+    }
     memcpy((void *)(uint8_t*)pEncryptedDataStart, pSecureToken, svp_token_size());
     svp_buffer_free_token(pSecureToken);
   }
@@ -1695,6 +1706,11 @@ CDMi_RESULT MediaKeySession::Decrypt(
 
     if(NULL != pDecryptedContent)
     {
+        if ((size_t)decryptedLength > actualEncDataLength) {
+            free(pDecryptedContent);
+            pDecryptedContent = NULL;
+            return CDMi_S_FALSE;
+        }
         memcpy((void *)(uint8_t*)pEncryptedDataStart, pDecryptedContent, decryptedLength);
         free(pDecryptedContent);
         pDecryptedContent = NULL;

--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -1432,7 +1432,11 @@ CDMi_RESULT MediaKeySession::Decrypt(
   DRM_BYTE* pDecryptedContent = NULL;
   DRM_BYTE*  pEncryptedData = NULL;
 
-  assert(sampleInfo->ivLength > 0);
+  if (sampleInfo->ivLength != EXPECTED_AES_CTR_IVDATA_SIZE &&
+      sampleInfo->ivLength != EXPECTED_AES_CBC_IVDATA_SIZE) {
+      fprintf(stderr, "[%s:%d] invalid ivLength %u\n", __FUNCTION__, __LINE__, sampleInfo->ivLength);
+      return CDMi_S_FALSE;
+  }
 
   bIsVideoResCheckNeed = svpIsVideoResCheckNeed();
 
@@ -1478,7 +1482,8 @@ CDMi_RESULT MediaKeySession::Decrypt(
 
   if (properties->InitLength()) {
       // Netflix case
-      memcpy(iv_vector, sampleInfo->iv, sampleInfo->ivLength * sizeof(uint8_t));
+      size_t ivCopyLen = (sampleInfo->ivLength <= sizeof(iv_vector)) ? sampleInfo->ivLength : sizeof(iv_vector);
+      memcpy(iv_vector, sampleInfo->iv, ivCopyLen);
 
   } else {
     // Regular case

--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -152,15 +152,17 @@ public:
         IMediaKeySession **f_ppiMediaKeySession) {
         bool isNetflixPlayready = (strstr(keySystem.c_str(), "netflix") != nullptr);
         if (isNetflixPlayready) {
+            SafeCriticalSection systemLock(drmAppContextMutex_);
             if(!m_isAppCtxInitialized)
             {
                 InitializeAppCtx();
-            }     
+            }
             *f_ppiMediaKeySession = new CDMi::MediaKeySession(f_pbInitData, f_cbInitData,  m_poAppContext.get(), !isNetflixPlayready);
          } else {
             *f_ppiMediaKeySession = new CDMi::MediaKeySession(f_pbInitData, f_cbInitData, f_pbCDMData, f_cbCDMData, m_poAppContext.get(), !isNetflixPlayready);
          }
-        return CDMi_SUCCESS; 
+        ++m_sessionCount;
+        return CDMi_SUCCESS;
     }
 
     CDMi_RESULT SetSecureStopPublisherCert( const DRM_BYTE *f_pbPublisherCert, DRM_DWORD f_cbPublisherCert )
@@ -207,6 +209,7 @@ public:
         if ( mediaKeySession != nullptr )
         {
             delete f_piMediaKeySession;
+            if (m_sessionCount > 0) --m_sessionCount;
         }
         else
         {
@@ -252,9 +255,11 @@ public:
             uint32_t drmHeaderLength,
             IMediaKeySessionExt** session) /* override */
     {
+        SafeCriticalSection systemLock(drmAppContextMutex_);
         bool isNetflixPlayready = (strstr(keySystem.c_str(), "netflix") != nullptr);
         printf("\n [TEL ELXSI] isNetflixPlayready is %d",&isNetflixPlayready);
         *session = new CDMi::MediaKeySession(drmHeader, drmHeaderLength, m_poAppContext.get(), !isNetflixPlayready);
+        ++m_sessionCount;
 
         return CDMi_SUCCESS;
     }
@@ -263,6 +268,7 @@ public:
     {
         SafeCriticalSection systemLock(drmAppContextMutex_);
         delete f_piMediaKeySession;
+        if (m_sessionCount > 0) --m_sessionCount;
         return CDMi_SUCCESS;
     }
 
@@ -498,6 +504,11 @@ public:
         bool bIsInitSecureClockNeed = false;
 
         if (m_poAppContext.get() != nullptr) {
+           if (m_sessionCount > 0) {
+               /* Existing MediaKeySession(s) hold raw m_poAppContext.get(); resetting here would dangle them. */
+               fprintf(stderr, "[%s:%d] InitializeAppCtx refused: %u session(s) still hold m_poAppContext\n",__FUNCTION__,__LINE__,m_sessionCount);
+               return CDMi_S_FALSE;
+           }
            m_poAppContext.reset();
         }
 
@@ -608,6 +619,13 @@ public:
     {
         DRM_BYTE *pbOldBuf = nullptr;
         DRM_DWORD cbOldBuf = 0;
+
+        if (m_sessionCount > 0)
+        {
+            /* Existing MediaKeySession(s) hold a raw alias of m_poAppContext.get(); freeing here is a UAF. */
+            fprintf(stderr, "[%s:%d] UninitializeAppCtx refused: %u session(s) still hold m_poAppContext\n",__FUNCTION__,__LINE__,m_sessionCount);
+            return CDMi_S_FALSE;
+        }
 
         m_isAppCtxInitialized = false;
 
@@ -819,6 +837,7 @@ private:
     DRM_BYTE *m_pbPublisherCert = nullptr;
     DRM_DWORD m_cbPublisherCert = 0;
     bool m_isAppCtxInitialized = false;
+    uint32_t m_sessionCount = 0;
 };
 
 static SystemFactoryType<PlayReady> g_instance({"video/x-h264", "audio/mpeg"});


### PR DESCRIPTION
What it does: Replaces the `assert(ivLength>0)` with a runtime check that `sampleInfo->ivLength` is exactly `EXPECTED_AES_CTR_IVDATA_SIZE` (8) or `EXPECTED_AES_CBC_IVDATA_SIZE` (16) — returning `CDMi_S_FALSE` otherwise — and additionally clamps the Netflix-path `memcpy` to `sizeof(iv_vector)`.